### PR TITLE
[ci skip] fix server api route and store trailing slash

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "precommit": "yarn test && lint-staged",
     "viz": "webpack --config webpack.dev.js --profile --progress --json > reports/stats.json && webpack-bundle-analyzer reports/stats.json",
     "report-cov": "cat ./coverage/lcov.info | codecov",
-    "dbg": "DEBUG=koa-router BABEL_ENV=server NODE_ENV=development node --inspect-brk server/server.js"
+    "dbg": "BABEL_ENV=server NODE_ENV=development node --inspect-brk server/server.js"
   },
   "lint-staged": {
     "*.{js,jsx,md,test.js.snap}": [

--- a/server/middleware/store.js
+++ b/server/middleware/store.js
@@ -1,7 +1,7 @@
+const url = require('url');
 const { useStaticRendering } = require('mobx-react');
-// const { toJS } = require('mobx');
 const { getServerConfig } = require('lib/utils');
-const RootStore = require('stores/RootStore').default; // import esm
+const RootStore = require('stores/RootStore').default;
 
 useStaticRendering(true);
 
@@ -19,12 +19,15 @@ module.exports = async (ctx, next) => {
   ctx.store.config = getServerConfig('app');
 
   // attach api server to ctx
-  let serverUrl = (getServerConfig('serverUrl') || '').trim();
-  let apiVer = (getServerConfig('apiVersion') || '').trim();
-  serverUrl = serverUrl.endsWith('/') ? serverUrl.substr(0, serverUrl.length - 1) : serverUrl;
-  apiVer = apiVer.startsWith('/') ? apiVer.substr(1) : apiVer;
+  let serverUrl = getServerConfig('serverUrl') || process.env.serverUrl || 'http://localhost:3000';
+  let apiVer = getServerConfig('apiVersion') || process.env.apiVersion || 'v1';
 
-  ctx.store.apiServer = `${serverUrl}/${apiVer}`;
+  if (!serverUrl.startsWith('http')) {
+    serverUrl = 'http://' + serverUrl;
+  }
+
+  // url.resolve need first string starts with http
+  ctx.store.apiServer = url.resolve(serverUrl, apiVer);
 
   await next();
 };

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -1,12 +1,10 @@
 const Router = require('koa-router');
 const agent = require('superagent');
-// const log=require('../log');
 
 const router = new Router();
 
 const header = {
   Accept: 'application/json',
-  // 'Content-Type': 'application/x-www-form-urlencoded'
   'Content-Type': 'application/json'
 };
 
@@ -17,7 +15,17 @@ router.post('/api/*', async ctx => {
     0,
     endpoint.indexOf('?') > -1 ? endpoint.indexOf('?') : endpoint.length
   );
-  let url = [ctx.store.apiServer, endpoint].join('/');
+
+  if (endpoint.startsWith('/')) {
+    endpoint = endpoint.substring(1);
+  }
+
+  let apiServer = ctx.store.apiServer;
+  if (apiServer.endsWith('/')) {
+    apiServer = apiServer.substring(0, apiServer.length - 1);
+  }
+
+  let url = [apiServer, endpoint].join('/');
 
   let body = ctx.request.body;
   let forwardMethod = body.method || 'get';


### PR DESCRIPTION
read `serverUrl`, 'apiVersion' from process.env